### PR TITLE
Adds unit tests for Pokémon API consumption

### DIFF
--- a/onTopPoke.xcodeproj/project.pbxproj
+++ b/onTopPoke.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		320ADA062D51A34F00FC12D1 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 320ADA052D51A34E00FC12D1 /* App.swift */; };
+		327501BD2D5281FE00792188 /* onTopPokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327501BC2D5281FE00792188 /* onTopPokeTests.swift */; };
+		327501C42D52829500792188 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327501C32D52829400792188 /* APIClient.swift */; };
+		327501C62D52834500792188 /* URLProtocolStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327501C52D52834500792188 /* URLProtocolStub.swift */; };
 		710FC3032A02DBA100899EA2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 710FC3022A02DBA100899EA2 /* Assets.xcassets */; };
 		710FC3062A02DBA100899EA2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 710FC3042A02DBA100899EA2 /* LaunchScreen.storyboard */; };
 		710FC30F2A02DD8100899EA2 /* APIRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710FC30E2A02DD8100899EA2 /* APIRoute.swift */; };
@@ -22,8 +25,22 @@
 		710FC3242A02E0B100899EA2 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 710FC3232A02E0B100899EA2 /* README.md */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		327501BE2D5281FE00792188 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 710FC2EE2A02DBA000899EA2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 710FC2F52A02DBA000899EA2;
+			remoteInfo = onTopPoke;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		320ADA052D51A34E00FC12D1 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
+		327501BA2D5281FE00792188 /* onTopPokeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = onTopPokeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		327501BC2D5281FE00792188 /* onTopPokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = onTopPokeTests.swift; sourceTree = "<group>"; };
+		327501C32D52829400792188 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		327501C52D52834500792188 /* URLProtocolStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolStub.swift; sourceTree = "<group>"; };
 		710FC2F62A02DBA000899EA2 /* onTopPoke.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = onTopPoke.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		710FC3022A02DBA100899EA2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		710FC3052A02DBA100899EA2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -41,6 +58,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		327501B72D5281FE00792188 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		710FC2F32A02DBA000899EA2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -51,11 +75,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		327501BB2D5281FE00792188 /* onTopPokeTests */ = {
+			isa = PBXGroup;
+			children = (
+				327501BC2D5281FE00792188 /* onTopPokeTests.swift */,
+				327501C32D52829400792188 /* APIClient.swift */,
+				327501C52D52834500792188 /* URLProtocolStub.swift */,
+			);
+			path = onTopPokeTests;
+			sourceTree = "<group>";
+		};
 		710FC2ED2A02DBA000899EA2 = {
 			isa = PBXGroup;
 			children = (
 				710FC3232A02E0B100899EA2 /* README.md */,
 				710FC2F82A02DBA000899EA2 /* onTopPoke */,
+				327501BB2D5281FE00792188 /* onTopPokeTests */,
 				710FC2F72A02DBA000899EA2 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -64,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				710FC2F62A02DBA000899EA2 /* onTopPoke.app */,
+				327501BA2D5281FE00792188 /* onTopPokeTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -123,6 +159,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		327501B92D5281FE00792188 /* onTopPokeTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 327501C22D5281FE00792188 /* Build configuration list for PBXNativeTarget "onTopPokeTests" */;
+			buildPhases = (
+				327501B62D5281FE00792188 /* Sources */,
+				327501B72D5281FE00792188 /* Frameworks */,
+				327501B82D5281FE00792188 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				327501BF2D5281FE00792188 /* PBXTargetDependency */,
+			);
+			name = onTopPokeTests;
+			productName = onTopPokeTests;
+			productReference = 327501BA2D5281FE00792188 /* onTopPokeTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		710FC2F52A02DBA000899EA2 /* onTopPoke */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 710FC30A2A02DBA100899EA2 /* Build configuration list for PBXNativeTarget "onTopPoke" */;
@@ -147,9 +201,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1430;
+				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					327501B92D5281FE00792188 = {
+						CreatedOnToolsVersion = 14.2;
+						TestTargetID = 710FC2F52A02DBA000899EA2;
+					};
 					710FC2F52A02DBA000899EA2 = {
 						CreatedOnToolsVersion = 14.3;
 					};
@@ -169,11 +227,19 @@
 			projectRoot = "";
 			targets = (
 				710FC2F52A02DBA000899EA2 /* onTopPoke */,
+				327501B92D5281FE00792188 /* onTopPokeTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		327501B82D5281FE00792188 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		710FC2F42A02DBA000899EA2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -187,6 +253,16 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		327501B62D5281FE00792188 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				327501BD2D5281FE00792188 /* onTopPokeTests.swift in Sources */,
+				327501C62D52834500792188 /* URLProtocolStub.swift in Sources */,
+				327501C42D52829500792188 /* APIClient.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		710FC2F22A02DBA000899EA2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -206,6 +282,14 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		327501BF2D5281FE00792188 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 710FC2F52A02DBA000899EA2 /* onTopPoke */;
+			targetProxy = 327501BE2D5281FE00792188 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin PBXVariantGroup section */
 		710FC3042A02DBA100899EA2 /* LaunchScreen.storyboard */ = {
 			isa = PBXVariantGroup;
@@ -218,6 +302,44 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		327501C02D5281FE00792188 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = H3V2LZ4MW4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Joseph.onTopPokeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/onTopPoke.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/onTopPoke";
+			};
+			name = Debug;
+		};
+		327501C12D5281FE00792188 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = H3V2LZ4MW4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = Joseph.onTopPokeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/onTopPoke.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/onTopPoke";
+			};
+			name = Release;
+		};
 		710FC3082A02DBA100899EA2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -397,6 +519,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		327501C22D5281FE00792188 /* Build configuration list for PBXNativeTarget "onTopPokeTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				327501C02D5281FE00792188 /* Debug */,
+				327501C12D5281FE00792188 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		710FC2F12A02DBA000899EA2 /* Build configuration list for PBXProject "onTopPoke" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/onTopPokeTests/APIClient.swift
+++ b/onTopPokeTests/APIClient.swift
@@ -1,0 +1,52 @@
+//
+//  APIClient.swift
+//  onTopPokeTests
+//
+//  Created by Liellison Menezes on 04/02/25.
+//
+
+import Foundation
+
+struct Pokemon: Decodable {
+    let id: Int
+    let name: String
+    let evolutionChain: [Int]
+}
+
+enum APIError: Error {
+    case networkError(Error)
+    case decodingError(Error)
+}
+
+protocol APIClientProtocol {
+    func fetchPokemon(completion: @escaping (Result<Pokemon, APIError>) -> Void)
+}
+
+class APIClient: APIClientProtocol {
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+    
+    func fetchPokemon(completion: @escaping (Result<Pokemon, APIError>) -> Void) {
+        let url = URL(string: "https://pokeapi.co/api/v2/pokemon-species")!
+        session.dataTask(with: url) { data, response, error in
+            if let error = error {
+                completion(.failure(.networkError(error)))
+                return
+            }
+            guard let data = data else {
+                completion(.failure(.networkError(NSError(domain: "No data", code: 0, userInfo: nil))))
+                return
+            }
+            do {
+                let pokemon = try JSONDecoder().decode(Pokemon.self, from: data)
+                completion(.success(pokemon))
+            } catch {
+                completion(.failure(.decodingError(error)))
+            }
+        }.resume()
+    }
+}
+

--- a/onTopPokeTests/URLProtocolStub.swift
+++ b/onTopPokeTests/URLProtocolStub.swift
@@ -1,0 +1,44 @@
+//
+//  URLProtocolStub.swift
+//  onTopPokeTests
+//
+//  Created by Liellison Menezes on 04/02/25.
+//
+
+import Foundation
+
+class URLProtocolStub: URLProtocol {
+    static var stubData: Data?
+    static var stubError: Error?
+    static var requestObserver: ((URLRequest) -> Void)?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+    
+    override func startLoading() {
+        if let observer = URLProtocolStub.requestObserver {
+            observer(request)
+        }
+        if let error = URLProtocolStub.stubError {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            if let data = URLProtocolStub.stubData {
+                self.client?.urlProtocol(self, didLoad: data)
+            }
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        self.client?.urlProtocolDidFinishLoading(self)
+    }
+    
+    override func stopLoading() {}
+}
+

--- a/onTopPokeTests/onTopPokeTests.swift
+++ b/onTopPokeTests/onTopPokeTests.swift
@@ -1,0 +1,117 @@
+//
+//  onTopPokeTests.swift
+//  onTopPokeTests
+//
+//  Created by Liellison Menezes on 04/02/25.
+//
+
+import XCTest
+@testable import onTopPoke
+
+class onTopPokeTests: XCTestCase {
+    var sut: APIClient!
+    var session: URLSession!
+    
+    override func setUp() {
+        super.setUp()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [URLProtocolStub.self]
+        session = URLSession(configuration: configuration)
+        sut = APIClient(session: session)
+    }
+    
+    override func tearDown() {
+        sut = nil
+        session = nil
+        URLProtocolStub.stubData = nil
+        URLProtocolStub.stubError = nil
+        URLProtocolStub.requestObserver = nil
+        super.tearDown()
+    }
+    
+    /// Tests the success scenario, where the JSON is valid and the model is decoded correctly.
+    func testFetchPokemon_SuccessfulResponse() {
+        let jsonString = """
+        {
+            "id": 1,
+            "name": "Bulbasaur",
+            "evolutionChain": [2, 3]
+        }
+        """
+        let data = jsonString.data(using: .utf8)
+        URLProtocolStub.stubData = data
+        
+        let expectation = self.expectation(description: "Fetch Pokemon")
+        
+        sut.fetchPokemon { result in
+            switch result {
+            case .success(let pokemon):
+                XCTAssertEqual(pokemon.id, 1)
+                XCTAssertEqual(pokemon.name, "Bulbasaur")
+                XCTAssertEqual(pokemon.evolutionChain, [2, 3])
+            case .failure(let error):
+                XCTFail("Expected success but got error: \(error)")
+            }
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+    
+    /// Tests the scenario where the received JSON is invalid for the expected model.
+    func testFetchPokemon_InvalidJSON() {
+        let invalidJSONString = """
+        {
+            "identifier": "invalid"
+        }
+        """
+        let data = invalidJSONString.data(using: .utf8)
+        URLProtocolStub.stubData = data
+        
+        let expectation = self.expectation(description: "Fetch Pokemon with invalid JSON")
+        
+        sut.fetchPokemon { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure due to invalid JSON, but succeeded.")
+            case .failure(let error):
+                switch error {
+                case .decodingError:
+                    XCTAssertTrue(true)
+                default:
+                    XCTFail("Expected a decoding error but got: \(error)")
+                }
+            }
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 5)
+    }
+    
+    /// Tests the scenario where a network error occurs (simulated).
+    func testFetchPokemon_NetworkError() {
+        let expectedError = NSError(domain: "NetworkError", code: -1, userInfo: nil)
+        URLProtocolStub.stubError = expectedError
+        
+        let expectation = self.expectation(description: "Fetch Pokemon with network error")
+        
+        sut.fetchPokemon { result in
+            switch result {
+            case .success:
+                XCTFail("Expected network error but got success.")
+            case .failure(let error):
+                switch error {
+                case .networkError(let error as NSError):
+                    XCTAssertEqual(error.domain, expectedError.domain)
+                    XCTAssertEqual(error.code, expectedError.code)
+                default:
+                    XCTFail("Expected a network error but got it: \(error)")
+                }
+            }
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 1)
+    }
+}
+


### PR DESCRIPTION
- Adiciona testes para cenários de resposta bem-sucedida, JSON inválido e erro de rede.
- Testa a decodificação do modelo de Pokémon a partir de JSON.
- Simula erro de rede com URLProtocolStub.